### PR TITLE
Add core/contrib security update issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/core_security_update.md
+++ b/.github/ISSUE_TEMPLATE/core_security_update.md
@@ -3,7 +3,7 @@ name: Core/security update
 about: Create a ticket to update Drupal core or a contributed module.
 title: ''
 labels: 'P3: high priority, dept: back-end :back:'
-assignees: 'cjming'
+assignees: ''
 
 ---
 <!-- Please apply all relevant labels including those to specify which sites are affected. -->

--- a/.github/ISSUE_TEMPLATE/core_security_update.md
+++ b/.github/ISSUE_TEMPLATE/core_security_update.md
@@ -1,0 +1,25 @@
+---
+name: Core/security update
+about: Create a ticket to update Drupal core or a contributed module.
+title: ''
+labels: 'P3: high priority, dept: back-end :back:'
+assignees: 'cjming'
+
+---
+<!-- Please apply all relevant labels including those to specify which sites are affected. -->
+
+## Description
+<!-- Provide documentation for the release that we should be updating to. -->
+<!-- [Releases for Drupal core](https://www.drupal.org/project/drupal/releases) -->
+
+## Release Notes
+<!-- Link to release notes for the new version. -->
+
+## Breaking Changes
+<!-- Denote any breaking changes from the release notes. -->
+
+## Security Concerns
+<!-- Denote any security concerns or additional security steps. -->
+
+## Additional Actions
+<!-- Denote additional actions that need to be taken our tested with this release. -->

--- a/.github/ISSUE_TEMPLATE/dependency_security_update.md
+++ b/.github/ISSUE_TEMPLATE/dependency_security_update.md
@@ -1,8 +1,8 @@
 ---
-name: Core/security update
-about: Create a ticket to update Drupal core or a contributed module.
+name: Dependency security update
+about: Create a ticket to update Drupal core, a contributed module, or another dependency.
 title: ''
-labels: 'P3: high priority, dept: back-end :back:'
+labels: 'P3: high priority'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -3,7 +3,7 @@ name: Epic
 about: Create an Epic to be considered the "parent" issue of a body of work.
 title: "[ epic ] "
 labels: epic
-assignees: markdorison
+assignees: ''
 
 ---
 


### PR DESCRIPTION
## Description
Add core/contrib security update issue template.

## Motivation / Context
Gets us closer to removing the templates from https://github.com/ChromaticHQ/benz-tickets/ as it adds the one issue type it has, that we don't have here.

Another question is wether we want a Drupal specific issue type in this general repo. I'm ok with it, but wanted to at least call it out.

## Testing Instructions / How This Has Been Tested
N/A

## Screenshots
N/A

## Documentation
N/A
