### PR TITLE
Disabled markdownlint line-length rule.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,10 +19,7 @@
 
 ## PR Author Checklist
 
-- [ ] My PR description includes a reference to a ticket or other "motivation"
-for these changes.
+- [ ] My PR description includes a reference to a ticket or other "motivation" for these changes.
 - [ ] My PR description includes details of how I tested these changes.
-- [ ] My PR description includes testing instructions for reviewers with links
-to the testing environment, if applicable.
-- [ ] My code includes documentation updates to existing documentation or new
-sections if applicable.
+- [ ] My PR description includes testing instructions for reviewers with links to the testing environment, if applicable.
+- [ ] My code includes documentation updates to existing documentation or new sections if applicable.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,2 +1,8 @@
 ---
+# Disable line length rule as hard wrapping makes issue/PR templates render strangely.
+# https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013---line-length
+MD013: false
+# Disable "first line in file should be a top level heading".
+# Our templates begin with H2's since it is assumed the issue/PR title will be the H1 on the page.
+# https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md041
 MD041: false


### PR DESCRIPTION
## Description

* Disabled markdownlint line-length rule.
* Added documentation to detail why certain rules are disabled.

## Motivation / Context

Hard wrapping in PR template was causing output to render strangely. @see https://github.com/ChromaticHQ/devops/pull/1447

## Testing Instructions / How This Has Been Tested
Tests should pass.

## Documentation
Updated in changeset.

## PR Author Checklist

- [x] My PR description includes a reference to a ticket or other "motivation" for these changes.
- [x] My PR description includes details of how I tested these changes.
- [x] My PR description includes testing instructions for reviewers with links to the testing environment, if applicable.
- [x] My code includes documentation updates to existing documentation or new sections if applicable.
