### PR TITLE
Added default Stalebot configuration.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+---
+# Number of days of inactivity before an issue becomes stale.
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed.
+daysUntilClose: 7
+# Issues with these labels will never be considered stale.
+exemptLabels:
+  - pinned
+  - "security :lock:"
+# Label to apply when marking an issue as stale.
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had any
+  recent activity. It will be closed if no further activity occurs. Issues with
+  "security" or "pinned" labels will be exempt from closure.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # Overview
 
-This repository exists to share Github templates with other repositories within
-the the [`ChromaticHQ`](https://github.com/ChromaticHQ) organization.
+This repository exists to share Github templates and configuration with other
+repositories within the the [`ChromaticHQ`](https://github.com/ChromaticHQ)
+organization.
 
 **This repository is public**. It needs to be public for other repositories to
 be able to leverage the templates that it provides.
 
 The approach was taken from
 [this help page](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file).
+
+## Stalebot Configuration
+The default [StaleBot](https://github.com/probot/stale)
+[configuration](.github/stale.yml) included in this repository can be enabled
+by configuring a repository's `.github/stale.yml` to contain the following:
+
+```yaml
+_extends: .github
+```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The approach was taken from
 [this help page](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file).
 
 ## Stalebot Configuration
+
 The default [StaleBot](https://github.com/probot/stale)
 [configuration](.github/stale.yml) included in this repository can be enabled
 by configuring a repository's `.github/stale.yml` to contain the following:


### PR DESCRIPTION
## Description
Added default Stalebot configuration.

## Motivation / Context
Can be [inherited](https://github.com/probot/stale/blob/673afc72556932d4fb777ad724e5b97aeec5decd/.github/stale.yml#L1) (or ignored/overridden) in our other organization repos.

## Testing Instructions / How This Has Been Tested
N/A

## Documentation
See diff.