### PR TITLE
Add OS and Browser Criteria to Bug Report Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,10 +16,17 @@ assignees: ''
 ## To Reproduce
 
 <!-- Steps to reproduce the bug: -->
+### Steps
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+
+<!-- The context in which this bug is replicable: -->
+### Environment
+- Operating system and version: <!-- Example: macOS 12.2.1, iOS 15, Windows 11, Android 12, etc. -->
+- Browser and version: <!-- Example: Chrome (Desktop) 99.0.4844.51, iOS 11.2 Safari, etc. -->
+- Device: <!-- Example: Desktop PC, Laptop, Surface Pro, iPhone X, etc. -->
 
 ## Expected Behavior
 


### PR DESCRIPTION
## Description
This PR suggests additional bug reporting criteria for the Bug Report Github Issue template used by all of our repos.

## Motivation / Context
Tickets like https://github.com/ChromaticHQ/benz-tickets/issues/2013 — although mistakenly not using the Bug Report template — would greatly benefit from knowing which OS and browser were used when the bug was produced.

## Testing Instructions / How This Has Been Tested
Read and make sure the words make sense.