### PR TITLE
Update setup- and launch-related issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/launch-analytics.md
+++ b/.github/ISSUE_TEMPLATE/launch-analytics.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Configure Google Tag Manager if applicable.
 - [ ] Configure Google Analytics or your analytics tool of choice.

--- a/.github/ISSUE_TEMPLATE/launch-analytics.md
+++ b/.github/ISSUE_TEMPLATE/launch-analytics.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Analytics
 about: Checklist of analytics related tasks to complete for a site launch.
-title: ''
+title: Launch - Analytics
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-analytics.md
+++ b/.github/ISSUE_TEMPLATE/launch-analytics.md
@@ -15,3 +15,4 @@ assignees: ''
 - [ ] Configure Google Tag Manager if applicable.
 - [ ] Configure Google Analytics or your analytics tool of choice.
 - [ ] Verify analytics tools are only reporting from the production environment or reporting separately depending on requirements.
+- [ ] Configure Sentry if applicable.

--- a/.github/ISSUE_TEMPLATE/launch-development.md
+++ b/.github/ISSUE_TEMPLATE/launch-development.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Development
 about: Checklist of development related tasks to complete for a site launch.
-title: ''
+title: Launch - Development
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-development.md
+++ b/.github/ISSUE_TEMPLATE/launch-development.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Verify that the mapping in `sites.php` supports the production domain.
 - [ ] Verify that PHP error messages are suppressed.

--- a/.github/ISSUE_TEMPLATE/launch-final.md
+++ b/.github/ISSUE_TEMPLATE/launch-final.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 ## Migration
 - [ ] Confirm that the content migration is complete.

--- a/.github/ISSUE_TEMPLATE/launch-final.md
+++ b/.github/ISSUE_TEMPLATE/launch-final.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Final
 about: Final checklist of tasks to complete before a site launch.
-title: ''
+title: Launch - Final
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-hosting.md
+++ b/.github/ISSUE_TEMPLATE/launch-hosting.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Determine who will provide the SSL certificate.
 - [ ] Setup HTTPS and test the SSL certificate.

--- a/.github/ISSUE_TEMPLATE/launch-hosting.md
+++ b/.github/ISSUE_TEMPLATE/launch-hosting.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Hosting
 about: Checklist of hosting related tasks to complete for a site launch.
-title: ''
+title: Launch - Hosting
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-performance.md
+++ b/.github/ISSUE_TEMPLATE/launch-performance.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Enable Drupal Page caching if applicable.
 - [ ] Enable Drupal Big Pipe caching if needed.

--- a/.github/ISSUE_TEMPLATE/launch-performance.md
+++ b/.github/ISSUE_TEMPLATE/launch-performance.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Performance
 about: Checklist of performance related tasks to complete for a site launch.
-title: ''
+title: Launch - Performance
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-planning.md
+++ b/.github/ISSUE_TEMPLATE/launch-planning.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Planning
 about: Checklist of initial planning related tasks to complete for a site launch.
-title: ''
+title: Launch - Planning
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-planning.md
+++ b/.github/ISSUE_TEMPLATE/launch-planning.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Determine when/if a content freeze should occur.
 - [ ] Determine who is responsible for entering/updating content and when that will occur.

--- a/.github/ISSUE_TEMPLATE/launch-post.md
+++ b/.github/ISSUE_TEMPLATE/launch-post.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 ## Development
 - [ ] Monitor site log for errors.

--- a/.github/ISSUE_TEMPLATE/launch-post.md
+++ b/.github/ISSUE_TEMPLATE/launch-post.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Post Launch
 about: Checklist of tasks to complete after a site launch.
-title: ''
+title: Launch - Post Launch
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-post.md
+++ b/.github/ISSUE_TEMPLATE/launch-post.md
@@ -21,7 +21,6 @@ assignees: ''
 - [ ] Confirm that third party integrations are working as expected.
 - [ ] Add site to [updown.io](https://updown.io) uptime monitoring.
 - [ ] Disable migration related modules and source database connectivity as applicable.
-- [ ] Configure Sentry if applicable.
 
 ## Ongoing Process
 - [ ] Update automated or manual tests to point to the new production domain.

--- a/.github/ISSUE_TEMPLATE/launch-qa.md
+++ b/.github/ISSUE_TEMPLATE/launch-qa.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - QA
 about: Checklist of QA related tasks to complete for a site launch.
-title: ''
+title: Launch - QA
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-qa.md
+++ b/.github/ISSUE_TEMPLATE/launch-qa.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Create a testing plan with milestones, impacts of missing key dates, how unknowns will be handled, etc and share it with all stakeholders.
 - [ ] Determine who is testing and what they are testing.

--- a/.github/ISSUE_TEMPLATE/launch-scope.md
+++ b/.github/ISSUE_TEMPLATE/launch-scope.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Scope
 about: Initial ticket used to define the launch scope and process.
-title: ''
+title: Launch - Scope
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/launch-security.md
+++ b/.github/ISSUE_TEMPLATE/launch-security.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Consider installing & configuring the [SecKit module](https://www.drupal.org/project/seckit).
 - [ ] Verify that development related accounts/passwords have been reset or removed.

--- a/.github/ISSUE_TEMPLATE/launch-security.md
+++ b/.github/ISSUE_TEMPLATE/launch-security.md
@@ -1,7 +1,7 @@
 ---
 name: Launch - Security
 about: Checklist of security related tasks to complete for a site launch.
-title: ''
+title: Launch - Security
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/project-setup.md
+++ b/.github/ISSUE_TEMPLATE/project-setup.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-Please check off line-items as they are completed and leave notes if necessary.
-If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text)
-(e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for
-any line-item, please update this description to include references to them.
+<!-- Please check off line-items as they are completed and leave notes if necessary. -->
+<!-- If an item is not relevant to this project, [strike it out](https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#styling-text) -->
+<!-- (e.g. `~~Not relevant item~~`) or remove it. If child tickets are created for -->
+<!-- any line-item, please update this description to include references to them. -->
 
 - [ ] Create a README.
 - [ ] Set up [Tugboat](https://dashboard.tugboat.qa/).

--- a/.github/ISSUE_TEMPLATE/project-setup.md
+++ b/.github/ISSUE_TEMPLATE/project-setup.md
@@ -1,7 +1,7 @@
 ---
-name: Setup
+name: Project Setup
 about: Prepare for development with basic project setup.
-title: ''
+title: Project Setup
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
## Description

This PR updates our issue templates to make the following improvements:
1. Move the Sentry configuration task to from the post-launch template to the Analytics template.
2. Add titles to the Launch templates as well as the Setup template to save developers the step of having to write a title for them, since these are unlikely to need unique titles.
3. In the Launch templates and the Setup template, put the instructions in HTML comments, so that they do not print if left in the issue description. This is consistent with what we do in other issue templates.
4. Rename the Setup template (filename `setup.md`) to Project Setup (filename `project-setup.md`), as that seems clearer about the nature of the tasks within it.

## Motivation / Context

In the case of the Sentry task move to Launch - Analytics, to get error reporting set up earlier in a project’s lifecycle. In the case of all other changes, to improve the developer experience while creating issues with these templates.

See chromatichq/devops#1621.

## Testing Instructions / How This Has Been Tested

A proofreading should suffice!

## Screenshots

n/a

## Documentation

n/a