### PR TITLE
Added the new template for Redesign tickets type.

### DIFF
--- a/.github/ISSUE_TEMPLATE/redesign-task.md
+++ b/.github/ISSUE_TEMPLATE/redesign-task.md
@@ -1,0 +1,22 @@
+---
+name: Redesign Task
+about: Create a task to describe redesign of specific element.
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+## Description
+
+<!-- A clear and concise description of the task. -->
+<!-- The sections suggested are intended to make it easy to create a -->
+<!-- descriptive issue Change as needed! -->
+
+## Design Mocks
+
+<!-- Provide the link/links to design mockups? -->
+
+## Screenshots
+
+<!-- Provide a screenshot of the element you are styling. -->


### PR DESCRIPTION
## Description
In this PR I created a new template for the redesign tasks. When creating new tickets for redesign projects we are not using the provided fields in the regular task template, from my research on the redesign tasks created by other FE devs and my own experience I realized that we need the following fields:

- Description
- Design Mocks
- Screenshots

I realized that I am slowed down by deleting unused fields and editing new ones when creating tasks using the default task template. 

## Motivation / Context
Improve productivity by having the necessary fields when creating new redesign tickets.

## Testing Instructions / How This Has Been Tested
Create a new Redesign Task. Confirm that the following fields are present:
- Description
- Design Mocks
- Screenshots

