### PR TITLE
Issue Templates: Add Issue Owner Section to Select Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,6 +13,17 @@ assignees: ''
 <!-- The sections suggested are intended to make it easy to create a -->
 <!-- descriptive bug report. Change as needed! -->
 
+## Issue Owner
+
+<!-- A list of one or more individuals, in most cases this is the client. -->
+<!-- Issue owner(s) have final say on whether the work associated with a -->
+<!-- ticket is ready to be deployed to production. All issue owners must -->
+<!-- approve any associated PRs before they may be merged. -->
+
+<!-- In rare cases, an issue owner may not be necessary. If this is the -->
+<!-- case, set this section to “n/a” and any PRs associated with it may be -->
+<!-- merged with only internal review. -->
+
 ## To Reproduce
 
 <!-- Steps to reproduce the bug: -->

--- a/.github/ISSUE_TEMPLATE/redesign-task.md
+++ b/.github/ISSUE_TEMPLATE/redesign-task.md
@@ -13,6 +13,17 @@ assignees: ''
 <!-- The sections suggested are intended to make it easy to create a -->
 <!-- descriptive issue Change as needed! -->
 
+## Issue Owner
+
+<!-- A list of one or more individuals, in most cases this is the client. -->
+<!-- Issue owner(s) have final say on whether the work associated with a -->
+<!-- ticket is ready to be deployed to production. All issue owners must -->
+<!-- approve any associated PRs before they may be merged. -->
+
+<!-- In rare cases, an issue owner may not be necessary. If this is the -->
+<!-- case, set this section to “n/a” and any PRs associated with it may be -->
+<!-- merged with only internal review. -->
+
 ## Design Mocks
 
 <!-- Provide the link/links to design mockups? -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -13,6 +13,17 @@ assignees: ''
 <!-- The sections suggested are intended to make it easy to create a -->
 <!-- descriptive issue Change as needed! -->
 
+## Issue Owner
+
+<!-- A list of one or more individuals, in most cases this is the client. -->
+<!-- Issue owner(s) have final say on whether the work associated with a -->
+<!-- ticket is ready to be deployed to production. All issue owners must -->
+<!-- approve any associated PRs before they may be merged. -->
+
+<!-- In rare cases, an issue owner may not be necessary. If this is the -->
+<!-- case, set this section to “n/a” and any PRs associated with it may be -->
+<!-- merged with only internal review. -->
+
 ## Proposed Solution
 
 <!-- What do you think should happen? -->


### PR DESCRIPTION
## Description

This PR adds an _Issue Owner_ section with guidelines to our _Bug_, _Redesign_, and _Task_ issue templates.

## Motivation / Context

This was proposed to —and well-received by— Imprivata. Production leads deemed it valuable enough to add it to our global issue templates.

Closes chromatichq/imprivata-drupal-8#2886.

## Testing Instructions / How This Has Been Tested

A proof-read should suffice.

## Screenshots

n/a

## Documentation

This is it!