### PR TITLE
Remove Preset Labels From Bug and Task Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve.
 title: ''
-labels: 'bug'
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Task
 about: Create a task to describe an enhancement or change that is not a bug.
 title: ''
-labels: 'enhancement'
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description
Per the discussion in [this Slack thread](https://chromatic.slack.com/archives/CHWLCPX0D/p1659360610076479), this removes the preset labels from the issue templates.

Let's ignore my horrid spelling in this effort 🤦 

## Motivation / Context
This was causing new and duplicate labels to be created automatically in the `benz-tickets` repo.

## Testing Instructions / How This Has Been Tested
Read the markdown docs and make sure I removed the labels properly.

## Screenshots
<!-- Would including screenshots be helpful to the reviewer? -->
N/A

## Documentation
<!-- Do any of the changes warrant documentation updates? -->
N/A
