### PR TITLE
Remove enhancement label from redesign task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/redesign-task.md
+++ b/.github/ISSUE_TEMPLATE/redesign-task.md
@@ -2,7 +2,7 @@
 name: Redesign Task
 about: Create a task to describe redesign of specific element.
 title: ''
-labels: 'enhancement'
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description

This PR removes the `enhacement` label from the _Redesign Task_ issue template.

## Motivation / Context

See [this Slack conversation](https://chromatic.slack.com/archives/CHWLCPX0D/p1659360610076479) and #27.

## Testing Instructions / How This Has Been Tested

Double-check the removal of the label.

## Screenshots

n/a

## Documentation

n/a