### PR TITLE
Add sub-bullet under README task in documentation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_review.md
+++ b/.github/ISSUE_TEMPLATE/documentation_review.md
@@ -13,6 +13,7 @@ Despite our best intentions, documentation frequently becomes outdated or incomp
 
 ## Tasks
 
-- [ ] Review the README for accuracy and completeness. 
+- [ ] Review the README for accuracy and completeness.
+    - If the README is very long, consider limiting this task to a specific section or group of sections.
 - [ ] Review all `@todo` statements in the codebase and resolve them or ensure that tickets are created for them.
 - [ ] Review Dependabot and GitHub config to ensure the correct usernames/labels/etc are being used.


### PR DESCRIPTION
## Description

This PR adds a sub-bullet under the README task of the documentation issue template which suggests alternatives for when a project's README is very long.

## Motivation / Context

After [some discussion in Slack](https://chromatic.slack.com/archives/C02AWL8TM/p1660681600173669?thread_ts=1660681600.173669&cid=C02AWL8TM), we decided this is a worthwhile addition to avoid making this task too daunting in the case of projects with very long README files.

## Testing Instructions / How This Has Been Tested

Proofreading should suffice.

## Documentation

A documentation section in a PR description for a change set to an issue template dedicated to keeping documentation up-to-date? This is more meta than my feeble mortal brain can handle. I refuse to fill this out.