### PR TITLE
Add acceptance criteria to bug, task, and redesign task

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -45,9 +45,9 @@ assignees: ''
 
 ## Acceptance Criteria
 
-<!-- A list of one or more requirements that must be met in order to for -->
-<!-- this ticket to be considered “done.” Use checkboxes to mark each item -->
-<!-- as an actionable task. -->
+<!-- A list of one or more requirements that must be met in order for this -->
+<!-- ticket to be considered “done.” Use checkboxes to mark each item as an -->
+<!-- actionable task. -->
 
 - [ ] TK
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -49,7 +49,7 @@ assignees: ''
 <!-- this ticket to be considered “done.” Use checkboxes to mark each item -->
 <!-- as an actionable task. -->
 
-- [ ] tk…
+- [ ] TK
 
 ## Screenshots
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,6 +43,14 @@ assignees: ''
 
 <!-- A description of what you expected to happen. -->
 
+## Acceptance Criteria
+
+<!-- A list of one or more requirements that must be met in order to for -->
+<!-- this ticket to be considered “done.” Use checkboxes to mark each item -->
+<!-- as an actionable task. -->
+
+- [ ] tk…
+
 ## Screenshots
 
 <!-- Would including screenshots help explain the problem? -->

--- a/.github/ISSUE_TEMPLATE/redesign-task.md
+++ b/.github/ISSUE_TEMPLATE/redesign-task.md
@@ -24,6 +24,14 @@ assignees: ''
 <!-- case, set this section to “n/a” and any PRs associated with it may be -->
 <!-- merged with only internal review. -->
 
+## Acceptance Criteria
+
+<!-- A list of one or more requirements that must be met in order to for -->
+<!-- this ticket to be considered “done.” Use checkboxes to mark each item -->
+<!-- as an actionable task. -->
+
+- [ ] tk…
+
 ## Design Mocks
 
 <!-- Provide the link/links to design mockups? -->

--- a/.github/ISSUE_TEMPLATE/redesign-task.md
+++ b/.github/ISSUE_TEMPLATE/redesign-task.md
@@ -26,9 +26,9 @@ assignees: ''
 
 ## Acceptance Criteria
 
-<!-- A list of one or more requirements that must be met in order to for -->
-<!-- this ticket to be considered “done.” Use checkboxes to mark each item -->
-<!-- as an actionable task. -->
+<!-- A list of one or more requirements that must be met in order for this -->
+<!-- ticket to be considered “done.” Use checkboxes to mark each item as an -->
+<!-- actionable task. -->
 
 - [ ] tk…
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -24,6 +24,14 @@ assignees: ''
 <!-- case, set this section to “n/a” and any PRs associated with it may be -->
 <!-- merged with only internal review. -->
 
+## Acceptance Criteria
+
+<!-- A list of one or more requirements that must be met in order to for -->
+<!-- this ticket to be considered “done.” Use checkboxes to mark each item -->
+<!-- as an actionable task. -->
+
+- [ ] tk…
+
 ## Proposed Solution
 
 <!-- What do you think should happen? -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -26,9 +26,9 @@ assignees: ''
 
 ## Acceptance Criteria
 
-<!-- A list of one or more requirements that must be met in order to for -->
-<!-- this ticket to be considered “done.” Use checkboxes to mark each item -->
-<!-- as an actionable task. -->
+<!-- A list of one or more requirements that must be met in order for this -->
+<!-- ticket to be considered “done.” Use checkboxes to mark each item as an -->
+<!-- actionable task. -->
 
 - [ ] tk…
 


### PR DESCRIPTION
## Description

This PR adds an _Acceptance Criteria_ section to our Bug, Task, and Redesign Task issue templates.

## Motivation / Context

Proposed during a recent Monthly Front-end Council meeting and approved by @lina-calin.

## Testing Instructions / How This Has Been Tested

A proof-read should suffice!