### PR TITLE
Update spike ticket outcomes section

### DIFF
--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -22,9 +22,12 @@ assignees: ''
 ## Outcome
 
 <!-- To be filled-in after all research has taken place. -->
-<!-- This may be an explanation of the issue or approach to be taken, -->
-<!-- a link to a newly-created milestone, a new task/bug ticket, or a -->
-<!-- combination thereof. -->
+<!-- This ideally would include an explanation of the issue and the approach -->
+<!-- to be taken and will typically result in a link to a newly-created -->
+<!-- milestone, a new task/bug ticket, or some combination thereof. Any -->
+<!-- tickets created as a result of this spike should be detailed and -->
+<!-- estimated to the best of your ability, including any applicable -->
+<!-- multiplier to account for PM time, reviews, admin time, or added risk. -->
 
 ## Additional Context
 


### PR DESCRIPTION
## Description

This PR updates our spike ticket template to add clarity to the _Outcome_ section. Of note, it now encourages the creation of detailed _and estimated_ (where possible) any tickets that are created as a result of the spike effort, as well as making sure that any estimates account for any applicable multipliers (such as those for QA time, PM time, or other factors that typically inflate the amount of time our team might spend on a task).

## Motivation / Context

Suggested in [this Slack thread](https://chromatic.slack.com/archives/CHWLCPX0D/p1673279885058479).

## Testing Instructions / How This Has Been Tested

A proofread should suffice. Opinions/discussion welcome!

## Screenshots

n/a

## Documentation

n/a