### PR TITLE
Remove Deprecated `tasklist`s From Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,6 +43,12 @@ assignees: ''
 
 <!-- A description of what you expected to happen. -->
 
+## Tasks
+
+<!-- A list of one or more requirements that must be met in order for this -->
+<!-- ticket to be considered “done.” -->
+- [ ] TK
+
 ## Screenshots
 
 <!-- Would including screenshots help explain the problem? -->
@@ -50,9 +56,3 @@ assignees: ''
 ## Additional context
 
 <!-- Is there any additional context that would be helpful? -->
-
-```[tasklist]
-### Tasks
-```
-<!-- A list of one or more requirements that must be met in order for this -->
-<!-- ticket to be considered “done.” -->

--- a/.github/ISSUE_TEMPLATE/redesign-task.md
+++ b/.github/ISSUE_TEMPLATE/redesign-task.md
@@ -28,12 +28,12 @@ assignees: ''
 
 <!-- Provide the link/links to design mockups? -->
 
+## Tasks
+
+<!-- A list of one or more requirements that must be met in order for this -->
+<!-- ticket to be considered “done.” -->
+- [ ] TK
+
 ## Screenshots
 
 <!-- Provide a screenshot of the element you are styling. -->
-
-```[tasklist]
-### Tasks
-```
-<!-- A list of one or more requirements that must be met in order for this -->
-<!-- ticket to be considered “done.” -->

--- a/.github/ISSUE_TEMPLATE/sentry_issue.md
+++ b/.github/ISSUE_TEMPLATE/sentry_issue.md
@@ -24,21 +24,19 @@ Resolves
 <!-- A list of one or more individuals, responsible for seeing this -->
 <!-- error or bug resolved/patched. -->
 
-
 ## Environment
-<!-- The context in which the report was filed. -->
 
+<!-- The context in which the report was filed. -->
 
 ## Suggested Solution
 
 <!-- What is the suggestion Sentry has provided? -->
 
+## Tasks
+
+<!-- What sub-tasks are part of this issue? -->
+- [ ] TK
 
 ## Screenshots
 
 <!-- Would including screenshots help explain the problem? -->
-
-
-```[tasklist]
-### Tasks
-```

--- a/.github/ISSUE_TEMPLATE/stackhawk_issue.md
+++ b/.github/ISSUE_TEMPLATE/stackhawk_issue.md
@@ -26,19 +26,18 @@ Resolves
 
 
 ## Environment
-<!-- The context in which the report was filed. -->
 
+<!-- The context in which the report was filed. -->
 
 ## Suggested Solution
 
 <!-- What is the suggestion StackHawk has provided? -->
 
+## Tasks
+
+<!-- What sub-tasks are part of this issue? -->
+- [ ] TK
 
 ## Screenshots
 
 <!-- Would including screenshots help explain the problem? -->
-
-
-```[tasklist]
-### Tasks
-```

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -37,8 +37,6 @@ assignees: ''
 
 <!-- Is there any additional context that would be helpful? -->
 
-```[tasklist]
-### Tasks
-```
-<!-- A list of one or more requirements that must be met in order for this -->
-<!-- ticket to be considered “done.” -->
+## Tasks
+<!-- What sub-tasks are part of this issue? -->
+- [ ] TK


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. The sections suggested are intended to make -->
<!-- it easy to create a descriptive PR that is easy to review. Change as needed! -->

Github is sunsetting the `tasklist` feature. It's final days are in April (IIRC). This PR simply replaces the `tasklist` markdown syntax with simply to-do syntax (`- [ ]`) in all of the applicaly issue templates.